### PR TITLE
docs: fix misspellings and update project plan status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SQRL `ssp.AuthStore` implementation using the GORM ORM.
 |------|--------|--------|
 | **SQRL Protocol Compliance** | **COMPLIANT** | All required storage fields (Idk, Suk, Vuk) plus optional enhancements |
 | **GORM Version** | **CURRENT (v2 -- gorm.io/gorm v1.31.1)** | Migrated from deprecated jinzhu/gorm v1.9.16 |
-| **Go Version** | 1.24 | Module initialised with Go 1.24.0 toolchain |
+| **Go Version** | 1.24 | Module initialized with Go 1.24.0 toolchain |
 | **Test Coverage** | 98.8% | 77 tests passing, 10 benchmarks. Target: 70%+ |
 | **CI/CD Pipeline** | Configured | GitHub Actions workflow with lint, security scan, coverage gate, build matrix |
 | **Security Hardening** | Integrated | Secure memory clearing + ValidateIdk + FindIdentitySecure + 13 security tests |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SQRL `ssp.AuthStore` implementation using the GORM ORM.
 |------|--------|--------|
 | **SQRL Protocol Compliance** | **COMPLIANT** | All required storage fields (Idk, Suk, Vuk) plus optional enhancements |
 | **GORM Version** | **CURRENT (v2 -- gorm.io/gorm v1.31.1)** | Migrated from deprecated jinzhu/gorm v1.9.16 |
-| **Go Version** | 1.24 | Module initialized with Go 1.24.0 toolchain |
+| **Go Version** | 1.24.7 | Module initialized with Go 1.24.7 toolchain |
 | **Test Coverage** | 98.8% | 77 tests passing, 10 benchmarks. Target: 70%+ |
 | **CI/CD Pipeline** | Configured | GitHub Actions workflow with lint, security scan, coverage gate, build matrix |
 | **Security Hardening** | Integrated | Secure memory clearing + ValidateIdk + FindIdentitySecure + 13 security tests |

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -2,9 +2,9 @@
 
 ## Consolidated Implementation Plan for gormauthstore
 
-**Version:** 3.0 (Consolidated from 4 planning documents)
-**Date:** February 5, 2026
-**Status:** Ready for execution -- Phase 1 is the critical path
+**Version:** 3.1 (Updated February 7, 2026)
+**Date:** February 7, 2026
+**Status:** Phase 1 complete, Phase 2 near complete (TASK-034 pending), Phase 3 not started
 
 ---
 
@@ -14,14 +14,14 @@
 |--------|-------|-------|
 | **GORM Version** | v2 (gorm.io/gorm v1.31.1) | Migrated from deprecated jinzhu/gorm v1.9.16 |
 | **Go Version** | 1.24.7 | go.mod min 1.24.0, toolchain go1.24.7 |
-| **Test Coverage** | ~98% | Target: 70%+. Unit + integration + security tests pass with SQLite |
-| **Security Scans** | CI/CD configured | gosec clean; govulncheck blocked by network |
+| **Test Coverage** | 98.8% | 77 tests, 10 benchmarks. Target: 70%+ |
+| **Security Scans** | CI/CD configured | gosec clean, golangci-lint v1.64.2, 13 security tests |
 | **Secure Memory** | Implemented | ClearIdentity, WipeBytes, SecureIdentityWrapper available |
 | **Input Validation** | Integrated | ValidateIdk() called by FindIdentity, SaveIdentity, DeleteIdentity |
 
 ### Completed (not repeated in tasks below)
 
-- Go module initialisation (`go.mod`, `go.sum`)
+- Go module initialization (`go.mod`, `go.sum`)
 - Secure memory functions (`secure_memory*.go`) -- safe copy-then-wipe implementation
 - Custom error types (`errors.go`)
 - CI/CD pipeline (`.github/workflows/ci.yml`)
@@ -316,6 +316,6 @@ The following documents were merged into this plan and moved to
 **Document Control:**
 - Consolidated from: UNIFIED_TODO.md, STAGED_UPGRADE_PLAN.md,
   SECURITY_REVIEW_AND_UPGRADE_PLAN.md, TODO.md
-- Total remaining tasks: 44
-- Estimated remaining effort: 26-34 hours
-- Decision points: 3 (DP-004 resolved -- no Goauthentik integration needed)
+- Total tasks: 44 (32 done, 11 pending, 1 deferred)
+- Estimated remaining effort: 6-8 hours
+- Decision points: 3 open (DP-001, DP-002, DP-003), 1 resolved (DP-004)


### PR DESCRIPTION
- README.md: fix "initialised" -> "initialized" (US English, misspell)
- PROJECT_PLAN.md: fix "initialisation" -> "initialization"
- PROJECT_PLAN.md: update status from "Ready for execution" to current progress (Phase 1 complete, Phase 2 near complete)
- PROJECT_PLAN.md: update document control (32/44 done, 6-8h remaining)
- PROJECT_PLAN.md: update test coverage and security scan metrics

https://claude.ai/code/session_01MhHeHe845GfpaimSsQ9HtT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Bumped project plan to v3.1 with updated date and phased progress tracking
  * Updated TL;DR/status table and clarified terminology (American English spelling)
  * Refined test coverage metrics (now 98.8%) and expanded security documentation/tests
  * Expanded phase/task details, decision-point statuses, risk register and rollback notes
  * Clarified narrative and superseded-PR rationale; improved overall document clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->